### PR TITLE
Abnormally shutdown the script on extracting birthmarks from invalid format classes

### DIFF
--- a/pochi-api/src/main/java/com/github/pochi/birthmarks/comparators/AbstractComparator.java
+++ b/pochi-api/src/main/java/com/github/pochi/birthmarks/comparators/AbstractComparator.java
@@ -1,6 +1,5 @@
 package com.github.pochi.birthmarks.comparators;
 
-import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 import com.github.pochi.birthmarks.AbstractTask;
@@ -22,14 +21,14 @@ public abstract class AbstractComparator extends AbstractTask<ComparatorType> im
     }
 
     @Override
-    public Comparisons compare(Birthmarks results, PairMatcher maker, BiConsumer<Birthmark, Birthmark> action){
-        return new Comparisons(compareWith(results, maker, action));
+    public Comparisons compare(Birthmarks results, PairMatcher maker){
+        return new Comparisons(compareWith(results, maker));
     }
 
     protected abstract Similarity calculate(Birthmark left, Birthmark right);
 
-    private Stream<Comparison> compareWith(Birthmarks extractedBirthmarks, PairMatcher maker, BiConsumer<Birthmark, Birthmark> action){
-        return maker.match(extractedBirthmarks)
-                .map(pair -> compare(pair, action));
+    private Stream<Comparison> compareWith(Birthmarks extractedBirthmarks, PairMatcher matcher){
+        return matcher.match(extractedBirthmarks)
+                .map(pair -> compare(pair));
     }
 }

--- a/pochi-api/src/main/java/com/github/pochi/birthmarks/comparators/AbstractComparator.java
+++ b/pochi-api/src/main/java/com/github/pochi/birthmarks/comparators/AbstractComparator.java
@@ -1,5 +1,6 @@
 package com.github.pochi.birthmarks.comparators;
 
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 import com.github.pochi.birthmarks.AbstractTask;
@@ -21,14 +22,14 @@ public abstract class AbstractComparator extends AbstractTask<ComparatorType> im
     }
 
     @Override
-    public Comparisons compare(Birthmarks results, PairMatcher maker){
-        return new Comparisons(compareWith(results, maker));
+    public Comparisons compare(Birthmarks results, PairMatcher maker, BiConsumer<Birthmark, Birthmark> action){
+        return new Comparisons(compareWith(results, maker, action));
     }
 
     protected abstract Similarity calculate(Birthmark left, Birthmark right);
 
-    private Stream<Comparison> compareWith(Birthmarks extractedBirthmarks, PairMatcher maker){
+    private Stream<Comparison> compareWith(Birthmarks extractedBirthmarks, PairMatcher maker, BiConsumer<Birthmark, Birthmark> action){
         return maker.match(extractedBirthmarks)
-                .map(pair -> compare(pair));
+                .map(pair -> compare(pair, action));
     }
 }

--- a/pochi-api/src/main/java/com/github/pochi/birthmarks/comparators/Comparator.java
+++ b/pochi-api/src/main/java/com/github/pochi/birthmarks/comparators/Comparator.java
@@ -1,7 +1,5 @@
 package com.github.pochi.birthmarks.comparators;
 
-import java.util.function.BiConsumer;
-
 import com.github.pochi.birthmarks.Task;
 import com.github.pochi.birthmarks.entities.Birthmark;
 import com.github.pochi.birthmarks.entities.Birthmarks;
@@ -12,24 +10,15 @@ public interface Comparator extends Task<ComparatorType> {
     @Override
     ComparatorType type();
 
-    Comparisons compare(Birthmarks results, PairMatcher maker, BiConsumer<Birthmark, Birthmark> action);
+    Comparisons compare(Birthmarks results, PairMatcher maker);
 
-    default Comparisons compare(Birthmarks results, PairMatcher maker) {
-        return compare(results, maker, (left, right) -> {});
-    }
-
-    default Comparison compare(Pair<Birthmark> pair, BiConsumer<Birthmark, Birthmark> action) {
-        action.accept(pair.left(), pair.right());
+    default Comparison compare(Pair<Birthmark> pair) {
         Similarity similarity = similarity(pair);
         return new Comparison(pair, similarity);
     }
 
     default Comparison compare(Birthmark left, Birthmark right) {
-        return compare(left, right, (birthmark1, birthmark2) -> {});
-    }
-
-    default Comparison compare(Birthmark left, Birthmark right, BiConsumer<Birthmark, Birthmark> action) {
-        return compare(new Pair<>(left, right), action);
+        return compare(new Pair<>(left, right));
     }
 
     Similarity similarity(Pair<Birthmark> pair);

--- a/pochi-api/src/main/java/com/github/pochi/birthmarks/comparators/Comparator.java
+++ b/pochi-api/src/main/java/com/github/pochi/birthmarks/comparators/Comparator.java
@@ -1,5 +1,7 @@
 package com.github.pochi.birthmarks.comparators;
 
+import java.util.function.BiConsumer;
+
 import com.github.pochi.birthmarks.Task;
 import com.github.pochi.birthmarks.entities.Birthmark;
 import com.github.pochi.birthmarks.entities.Birthmarks;
@@ -10,15 +12,24 @@ public interface Comparator extends Task<ComparatorType> {
     @Override
     ComparatorType type();
 
-    Comparisons compare(Birthmarks results, PairMatcher maker);
+    Comparisons compare(Birthmarks results, PairMatcher maker, BiConsumer<Birthmark, Birthmark> action);
 
-    default Comparison compare(Pair<Birthmark> pair) {
+    default Comparisons compare(Birthmarks results, PairMatcher maker) {
+        return compare(results, maker, (left, right) -> {});
+    }
+
+    default Comparison compare(Pair<Birthmark> pair, BiConsumer<Birthmark, Birthmark> action) {
+        action.accept(pair.left(), pair.right());
         Similarity similarity = similarity(pair);
         return new Comparison(pair, similarity);
     }
 
     default Comparison compare(Birthmark left, Birthmark right) {
-        return compare(new Pair<>(left, right));
+        return compare(left, right, (birthmark1, birthmark2) -> {});
+    }
+
+    default Comparison compare(Birthmark left, Birthmark right, BiConsumer<Birthmark, Birthmark> action) {
+        return compare(new Pair<>(left, right), action);
     }
 
     Similarity similarity(Pair<Birthmark> pair);

--- a/pochi-api/src/main/java/com/github/pochi/birthmarks/extractors/AbstractExtractor.java
+++ b/pochi-api/src/main/java/com/github/pochi/birthmarks/extractors/AbstractExtractor.java
@@ -3,8 +3,7 @@ package com.github.pochi.birthmarks.extractors;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
+import java.util.function.BiConsumer;
 
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -13,31 +12,26 @@ import com.github.pochi.birthmarks.AbstractTask;
 import com.github.pochi.birthmarks.config.Configuration;
 import com.github.pochi.birthmarks.entities.Birthmark;
 import com.github.pochi.birthmarks.entities.BirthmarkType;
-import com.github.pochi.birthmarks.entities.FailedSources;
-import com.github.pochi.birthmarks.entities.Metadata;
 import com.github.pochi.kunai.entries.Entry;
 
 public abstract class AbstractExtractor extends AbstractTask<BirthmarkType> implements Extractor {
-    private FailedSources failedSources = new FailedSources();
-    
     public AbstractExtractor(BirthmarkType type, Configuration config){
         super(type, config);
     }
 
     @Override
-    public final Optional<Birthmark> extractEach(Entry entry, Consumer<Entry> action) {
+    public final Optional<Birthmark> extractEach(Entry entry, BiConsumer<Entry, Exception> callbackOnError) {
         try {
-            return Optional.of(extractImpl(entry, action));
-        } catch (IOException e) {
+            return Optional.of(extractImpl(entry));
+        } catch (Exception e) {
+            callbackOnError.accept(entry, e);
         }
-        failedSources.add(Metadata.build(entry));
         return Optional.empty();
     }
 
-    private Birthmark extractImpl(Entry entry, Consumer<Entry> action) throws IOException {
+    private Birthmark extractImpl(Entry entry) throws IOException {
         try (InputStream in = entry.openStream()) {
             PochiClassVisitor visitor = visitor(new ClassWriter(0));
-            action.accept(entry);
             return accept(in, entry, visitor);
         }
     }
@@ -46,10 +40,5 @@ public abstract class AbstractExtractor extends AbstractTask<BirthmarkType> impl
         ClassReader reader = new ClassReader(in);
         reader.accept(visitor, ClassReader.SKIP_DEBUG);
         return visitor.build(entry);
-    }
-
-    @Override
-    public final Stream<Metadata> failedSources() {
-        return failedSources.stream();
     }
 }

--- a/pochi-api/src/main/java/com/github/pochi/birthmarks/extractors/AbstractExtractor.java
+++ b/pochi-api/src/main/java/com/github/pochi/birthmarks/extractors/AbstractExtractor.java
@@ -3,6 +3,7 @@ package com.github.pochi.birthmarks.extractors;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.objectweb.asm.ClassReader;
@@ -24,18 +25,19 @@ public abstract class AbstractExtractor extends AbstractTask<BirthmarkType> impl
     }
 
     @Override
-    public final Optional<Birthmark> extractEach(Entry entry) {
+    public final Optional<Birthmark> extractEach(Entry entry, Consumer<Entry> action) {
         try {
-            return Optional.of(extractImpl(entry));
+            return Optional.of(extractImpl(entry, action));
         } catch (IOException e) {
         }
         failedSources.add(Metadata.build(entry));
         return Optional.empty();
     }
 
-    private Birthmark extractImpl(Entry entry) throws IOException {
+    private Birthmark extractImpl(Entry entry, Consumer<Entry> action) throws IOException {
         try (InputStream in = entry.openStream()) {
             PochiClassVisitor visitor = visitor(new ClassWriter(0));
+            action.accept(entry);
             return accept(in, entry, visitor);
         }
     }

--- a/pochi-api/src/main/java/com/github/pochi/birthmarks/extractors/Extractor.java
+++ b/pochi-api/src/main/java/com/github/pochi/birthmarks/extractors/Extractor.java
@@ -1,7 +1,7 @@
 package com.github.pochi.birthmarks.extractors;
 
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 import org.objectweb.asm.ClassVisitor;
@@ -10,7 +10,6 @@ import com.github.pochi.birthmarks.Task;
 import com.github.pochi.birthmarks.entities.Birthmark;
 import com.github.pochi.birthmarks.entities.BirthmarkType;
 import com.github.pochi.birthmarks.entities.Birthmarks;
-import com.github.pochi.birthmarks.entities.Metadata;
 import com.github.pochi.kunai.entries.Entry;
 import com.github.pochi.kunai.source.DataSource;
 
@@ -19,26 +18,24 @@ public interface Extractor extends Task<BirthmarkType>{
     BirthmarkType type();
 
     default Stream<Birthmark> extractForStream(DataSource source){
-        return extractForStream(source, entry -> {});
+        return extractForStream(source, (entry, exception) -> {});
     }
-    default Stream<Birthmark> extractForStream(DataSource source, Consumer<Entry> action){
+    default Stream<Birthmark> extractForStream(DataSource source, BiConsumer<Entry, Exception> callbackOnError){
         Stream<Optional<Birthmark>> stream = source.stream()
                 .filter(entry -> entry.endsWith(".class"))
-                .map(entry -> extractEach(entry, action));
+                .map(entry -> extractEach(entry, callbackOnError));
         return filter(stream);
     }
 
     default Birthmarks extract(DataSource source){
-        return extract(source, entry -> {});
+        return extract(source, (entry, exception) -> {});
     }
 
-    default Birthmarks extract(DataSource source, Consumer<Entry> action){
+    default Birthmarks extract(DataSource source, BiConsumer<Entry, Exception> action){
         return new Birthmarks(extractForStream(source, action));
     }
 
     PochiClassVisitor visitor(ClassVisitor visitor);
 
-    Optional<Birthmark> extractEach(Entry entry, Consumer<Entry> action);
-
-    Stream<Metadata> failedSources();
+    Optional<Birthmark> extractEach(Entry entry, BiConsumer<Entry, Exception> action);
 }

--- a/pochi-api/src/main/java/com/github/pochi/birthmarks/extractors/Extractor.java
+++ b/pochi-api/src/main/java/com/github/pochi/birthmarks/extractors/Extractor.java
@@ -1,6 +1,7 @@
 package com.github.pochi.birthmarks.extractors;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.objectweb.asm.ClassVisitor;
@@ -18,19 +19,26 @@ public interface Extractor extends Task<BirthmarkType>{
     BirthmarkType type();
 
     default Stream<Birthmark> extractForStream(DataSource source){
+        return extractForStream(source, entry -> {});
+    }
+    default Stream<Birthmark> extractForStream(DataSource source, Consumer<Entry> action){
         Stream<Optional<Birthmark>> stream = source.stream()
                 .filter(entry -> entry.endsWith(".class"))
-                .map(entry -> extractEach(entry));
+                .map(entry -> extractEach(entry, action));
         return filter(stream);
     }
 
     default Birthmarks extract(DataSource source){
-        return new Birthmarks(extractForStream(source));
+        return extract(source, entry -> {});
+    }
+
+    default Birthmarks extract(DataSource source, Consumer<Entry> action){
+        return new Birthmarks(extractForStream(source, action));
     }
 
     PochiClassVisitor visitor(ClassVisitor visitor);
 
-    Optional<Birthmark> extractEach(Entry entry);
+    Optional<Birthmark> extractEach(Entry entry, Consumer<Entry> action);
 
     Stream<Metadata> failedSources();
 }

--- a/pochi-runner/src/main/java/com/github/pochi/runner/scripts/ScriptRunnerBuilder.java
+++ b/pochi-runner/src/main/java/com/github/pochi/runner/scripts/ScriptRunnerBuilder.java
@@ -38,7 +38,7 @@ public class ScriptRunnerBuilder {
 
     public ScriptRunner build(Map<String, Object> properties){
         ScriptEngine engine = buildImpl(properties);
-        
+
         return new ScriptRunner(engine, configuration);
     }
 

--- a/pochi-runner/src/sample/js/extract.js
+++ b/pochi-runner/src/sample/js/extract.js
@@ -2,8 +2,12 @@ extract = function(type, from){
     extractor = engine.extractor(type);
     source = engine.source(from)
     obj = {}
+    callbackOnExtractionError = function(entry, exception){
+        // some operation for logging error sources.
+    }
     obj.time = sys.measure(function(){
-        obj.birthmarks = extractor.extract(source);
+        // obj.birthmarks = extractor.extract(source); // no call back function is OK!
+        obj.birthmarks = extractor.extract(source, callbackOnExtractionError);
     })
     return obj;
 }


### PR DESCRIPTION
不正なフォーマットのクラスを読むと，IOException 以外が発生するので，プログラムが途中で終わる．

不正終了しないように，Exception をキャッチするようにし，エラーが起こった箇所でコールバック関数を呼ぶようにした．